### PR TITLE
Moved switch case to function pointer based approach.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 
 # Debug files
 *.dSYM/
+
+# Ignore the binary output
+fvm

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 CFLAGS=-I.
 
+SRC=$(wildcard *.c)
+
 %.o: %.c
 	$(CC) -c -o $@ $< $(CFLAGS)
 

--- a/fvm.c
+++ b/fvm.c
@@ -1,32 +1,13 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "opcodes.h"
 
-#define NUM_REGS 16
 #define PROG_LENGTH 4096
-unsigned regs[NUM_REGS];
-unsigned memory[0xFFF];
+
 unsigned int prog[PROG_LENGTH];
 
-/* Program Counter */
-int pc = 1;
-
 int comment = 0;
-
-/* Fields */
-int instruction = 0;
-int n1 = 0;
-int n2 = 0;
-int n3 = 0;
-int n4 = 0;
-int l2 = 0;
-int l3 = 0;
-int l4 = 0;
-int t1 = 0;
-int t2 = 0;
-int w = 0;
-int m1 = 0;
-int m2 = 0;
 
 /* Gets all the information out of the instruction */
 void decode(int in){
@@ -45,90 +26,13 @@ void decode(int in){
   m2 = (in & 0xFFF);
 }
 
-/* Is the VM running? */
-int running = 0;
-
 void eval(){
-  switch(instruction){
-    case 0: /*stp*/
-      running = 0;
-      break;
-    case 1: /*ldi*/
-      regs[n1] = l3;
-      break;
-    case 2: /*rst*/
-      regs[n1] = 0;
-      break;
-    case 3: /*gto*/
-      pc = l4;
-      break;
-    case 4: /*add*/
-      regs[n3] = regs[n1] + regs[n2];
-      break;
-    case 5: /*sub*/
-      regs[n3] = regs[n1] - regs[n2];
-      break;
-    case 6: /*mul*/
-      regs[n3] = regs[n1] * regs[n2];
-      break;
-    case 7: /*div*/
-      regs[n3] = regs[n1] / regs[n2];
-      break;
-    case 8: /*mod*/
-      regs[n3] = regs[n1] % regs[n2];
-      break;
-    case 9: /*and*/
-      regs[n3] = regs[n1] & regs[n2];
-      break;
-    case 10: /*or*/
-      regs[n3] = regs[n1] | regs[n2];
-      break;
-    case 11: /*xor*/
-      regs[n3] = regs[n1] ^ regs[n2];
-      break;
-    case 12: /*not*/
-      regs[n2] = !regs[n1];
-      break;
-    case 13: /*shl*/
-      regs[n3] = regs[n1] << regs[n2];
-      break;
-    case 14: /*shr*/
-      regs[n3] = regs[n1] >> regs[n2];
-      break;
-    case 15: /*str*/
-      memory[t1] = regs[n1];
-      break;
-    case 16: /*get*/
-      regs[n3] = memory[t2];
-      break;
-    case 17: /*red*/
-      scanf("%d", &regs[n1]);
-      break;
-    case 18: /*prt*/
-      printf("%d", regs[n1]);
-      break;
-    case 19: /*prc*/
-      printf("%c", regs[n1]);
-      break;
-    case 20: /*trn*/
-      regs[n2] = regs[n1];
-      break;
-    case 21: /*bnz*/
-      if (regs[n1] != 0) pc = m2;
-      break;
-    case 22: /*biz*/
-      if (regs[n1] == 0) pc = m2;
-      break;
-    case 23: /*neg*/
-      regs[n2] = -regs[n1];
-      break;
-    case 24: /*btc*/
-      regs[n2] = ~regs[n1];
-      break;
-    default:
-      printf("Error: Instruction %X not found!", instruction);
-      exit(EXIT_FAILURE);
-  }
+    if (instruction > -1 && instruction < 25) {
+        operations[instruction]();
+    }
+    else {
+        error();
+    }
 }
 
 int fetch(){

--- a/opcodes.h
+++ b/opcodes.h
@@ -1,0 +1,162 @@
+/* Registers for VM */
+#define NUM_REGS 16
+unsigned regs[NUM_REGS];
+
+unsigned memory[0xFFF];
+
+/* Program Counter */
+int pc = 1;
+
+/* Fields */
+int instruction = 0;
+int n1 = 0;
+int n2 = 0;
+int n3 = 0;
+int n4 = 0;
+int l2 = 0;
+int l3 = 0;
+int l4 = 0;
+int t1 = 0;
+int t2 = 0;
+int w = 0;
+int m1 = 0;
+int m2 = 0;
+
+/* Is the program running? */
+int running = 0;
+
+typedef void (*func)();
+
+
+void stp() {
+    running = 0;
+}
+
+void ldi() {
+    regs[n1] = l3;
+}
+
+void rst() {
+    regs[n1] = 0;
+}
+
+void gto() {
+    pc = l4;
+}
+
+void add() {
+    regs[n3] = regs[n1] + regs[n2];
+}
+
+void sub() {
+    regs[n3] = regs[n1] - regs[n2];
+}
+
+void mul() {
+    regs[n3] = regs[n1] * regs[n2];
+}
+
+void divide() {
+    regs[n3] = regs[n1] / regs[n2];
+}
+
+void mod() {
+    regs[n3] = regs[n1] % regs[n2];
+}
+
+void and() {
+    regs[n3] = regs[n1] & regs[n2];
+}
+
+void or() {
+    regs[n3] = regs[n1] | regs[n2];
+}
+
+void xor() {
+    regs[n3] = regs[n1] ^ regs[n2];
+}
+
+void not() {
+    regs[n2] = !regs[n1];
+}
+
+void shl() {
+    regs[n3] = regs[n1] << regs[n2];
+}
+
+void shr() {
+    regs[n3] = regs[n1] >> regs[n2];
+}
+
+void str() {
+    memory[t1] = regs[n1];
+}
+
+void get() {
+    regs[n3] = memory[t2];
+}
+
+void red() {
+    scanf("%d", &regs[n1]);
+}
+
+void prt() {
+    printf("%d", regs[n1]);
+}
+
+void prc() {
+    printf("%c", regs[n1]);
+}
+
+void trn() {
+    regs[n2] = regs[n1];
+}
+
+void bnz() {
+    if (regs[n1] != 0) pc = m2;
+}
+
+void biz() {
+    if (regs[n1] == 0) pc = m2;
+}
+
+void neg() {
+    regs[n2] = -regs[n1];
+}
+
+void btc() {
+    regs[n2] = ~regs[n1];
+}
+
+void error() {
+    printf("Error: Instruction %X not found!", instruction);
+    exit(EXIT_FAILURE);
+}
+
+func operations[] = {
+    stp,
+    ldi,
+    rst,
+    gto,
+    add,
+    sub,
+    mul,
+    divide,
+    mod,
+    and,
+    or,
+    xor,
+    not,
+    shl,
+    shr,
+    str,
+    get,
+    red,
+    prt,
+    prc,
+    trn,
+    bnz,
+    biz,
+    neg,
+    btc
+};


### PR DESCRIPTION
Instead of using one big switch case for the eval function I broke it up into two source files.

"opcodes.h" contains a function pointer of valid instructions (or "opcodes") that eval calls by doing:

```
opcodes[instruction]();
```

Consider reading this as to why a function pointer approach may be better:

http://richardhartersworld.com/cri/2008/transfer.html
